### PR TITLE
argument 중 실행파일 내용은 빼고 인자만 전달하도록 수정

### DIFF
--- a/DeepDiveIntoSSD/ssd/main.cpp
+++ b/DeepDiveIntoSSD/ssd/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char* argv[])
 	Writer writer;
 	ArgManager argManager;
 	SSD ssd(&reader, &writer, &argManager);
-	ssd.run(argc, argv);
+	ssd.run(argc - 1, argv + 1);
 	return 0;
 #endif
 }


### PR DESCRIPTION
ssd.exe W 1 0x12545 입력 시 argument 가 아래와 같이 세팅되어
argmanager 로 argv[0] 를 빼서 전달하도록 수정하였습니다.
4 ssd.exe
4 w
4 1
4 0x12545