### PR TITLE
write 성공 시 dumpsuccess 하도록 수정

### DIFF
--- a/DeepDiveIntoSSD/ssd/Ssd.cpp
+++ b/DeepDiveIntoSSD/ssd/Ssd.cpp
@@ -41,6 +41,7 @@ void SSD::run(int argc, char* argv[]) {
 		flushBuffers();
 	}
 	m_commandBuffer->pushBuffer(arg);
+	dumpSuccess();
 	return;
 }
 


### PR DESCRIPTION
기존방식 : write 시 error 가 아니면 commandbuffer 에 명령어가 쌓여 ssd_output.txt 에 반영이 안됨.
새로운 방식 : write 시 error 가 아니면 commandbuffer 에도 명령어가 쌓이고 dumpsuccess 를 통해 ssd_output.txt 에 반영되도록 함